### PR TITLE
Fix decimal precision when reading numbers

### DIFF
--- a/Tests/Audacia.Spreadsheets.Tests/PrecisionParsingTests.cs
+++ b/Tests/Audacia.Spreadsheets.Tests/PrecisionParsingTests.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using Xunit;
+
+namespace Audacia.Spreadsheets.Tests
+{
+    public class PrecisionParsingTests
+    {
+        [Fact]
+        public void Excess_precision_numbers_are_normalized()
+        {
+            byte[] bytes;
+            using (var ms = new MemoryStream())
+            {
+                using (var spreadsheet = SpreadsheetDocument.Create(ms, SpreadsheetDocumentType.Workbook, true))
+                {
+                    var workbookPart = spreadsheet.AddWorkbookPart();
+                    workbookPart.Workbook = new Workbook();
+
+                    var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+                    var sheetData = new SheetData();
+                    worksheetPart.Worksheet = new Worksheet(sheetData);
+
+                    var sheets = workbookPart.Workbook.AppendChild(new Sheets());
+                    var sheet = new Sheet { Id = workbookPart.GetIdOfPart(worksheetPart), SheetId = 1, Name = "Sheet1" };
+                    sheets.Append(sheet);
+
+                    var row = new Row();
+                    var cell = new Cell { CellReference = "A1", DataType = CellValues.Number };
+                    cell.CellValue = new CellValue("1.10000000001");
+                    row.Append(cell);
+                    sheetData.Append(row);
+                }
+
+                bytes = ms.ToArray();
+            }
+
+            var worksheet = Spreadsheet.FromBytes(bytes).Worksheets[0];
+            var value = (decimal)worksheet.Table.Rows.First().Cells.First().Value!;
+            Assert.Equal(1.1m, value);
+        }
+    }
+}
+

--- a/src/Audacia.Spreadsheets/TableRow.cs
+++ b/src/Audacia.Spreadsheets/TableRow.cs
@@ -150,7 +150,7 @@ namespace Audacia.Spreadsheets
                                 {
                                     if (!valueAdded && decimal.TryParse(matchedCell.CellValue!.Text, out var value))
                                     {
-                                        newCell.Value = value;
+                                        newCell.Value = NormalizeDecimal(matchedCell.CellValue!.Text, value);
                                         cellData.Add(newCell);
                                         valueAdded = true;
                                     }
@@ -241,6 +241,19 @@ namespace Audacia.Spreadsheets
             return colour != null && colour.Auto?.HasValue == true && colour.Rgb?.HasValue == true
                     ? colour.Rgb?.Value?.Substring(2)
                     : null;
+        }
+
+        private static decimal NormalizeDecimal(string sourceText, decimal value)
+        {
+            var decimalPointIndex = sourceText.IndexOf('.');
+            if (decimalPointIndex >= 0 && sourceText.Length - decimalPointIndex - 1 > 10)
+            {
+                value = Math.Round(value, 10);
+            }
+
+            var stringValue = value.ToString(CultureInfo.InvariantCulture);
+            stringValue = stringValue.Contains('.') ? stringValue.TrimEnd('0').TrimEnd('.') : stringValue;
+            return decimal.Parse(stringValue, CultureInfo.InvariantCulture);
         }
 
 #pragma warning disable AV1553


### PR DESCRIPTION
## Summary
- trim excess precision when reading numeric values from spreadsheets
- test normalizing of excess precision numbers

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68543fa6fd3c832fba3a95332e5696c5